### PR TITLE
transmit offers via websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +265,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
 dependencies = [
- "http",
+ "http 0.2.11",
  "log",
  "url",
 ]
@@ -409,6 +424,21 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1001,7 +1031,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap",
  "slab",
  "tokio",
@@ -1028,7 +1058,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.11",
  "httpdate",
  "mime",
  "sha1",
@@ -1040,7 +1070,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.11",
 ]
 
 [[package]]
@@ -1175,13 +1205,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
@@ -1214,7 +1255,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -1234,11 +1275,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1300,7 +1364,7 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
  "rand",
@@ -1944,7 +2008,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "memchr",
@@ -2558,7 +2622,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -2934,14 +2998,17 @@ version = "0.0.5"
 dependencies = [
  "async-trait",
  "bech32",
+ "chrono",
  "clap",
  "env_logger",
  "futures",
+ "futures-util",
  "libp2p",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tracing",
  "tracing-subscriber",
  "warp",
@@ -3154,7 +3221,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -3254,7 +3333,26 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.11",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
  "httparse",
  "log",
  "rand",
@@ -3412,7 +3510,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
  "mime",
@@ -3427,7 +3525,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,31 @@ edition = "2021"
 tokio = { version = "1.35", features = ["full"] }
 async-trait = "0.1"
 futures = "0.3.30"
-libp2p = { version = "0.53.2", features = [ "tokio", "gossipsub", "kad", "noise", "macros", "identify", "tcp", "yamux", "secp256k1", "dns"] }
+libp2p = { version = "0.53.2", features = [
+  "tokio",
+  "gossipsub",
+  "kad",
+  "noise",
+  "macros",
+  "identify",
+  "tcp",
+  "yamux",
+  "secp256k1",
+  "dns",
+] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 env_logger = "0.11.1"
 clap = { version = "4.4.17", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.11.23", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.11.23", default-features = false, features = [
+  "blocking",
+  "json",
+  "rustls-tls",
+] }
 warp = "0.3.6"
 bech32 = "0.9.1"
+futures-util = "0.3.28"
+tokio-tungstenite = "0.21.0"
+chrono = { version = "0.4.24", features = ["serde"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use clap::Parser;
 use futures::stream::StreamExt;
 use libp2p::multiaddr::Protocol;
@@ -15,7 +16,6 @@ use std::time::Duration;
 use tokio::{io, select, time};
 use tracing_subscriber::EnvFilter;
 use warp::Filter;
-use chrono::{DateTime, Utc};
 use ws::{channel, server};
 mod ws;
 
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let (sender, receiver) = tokio::sync::mpsc::channel(100);
-    if let Some(address) = opt.offer_webhook.clone() {
+    if let Some(address) = opt.offer_websocket.clone() {
         let server = server::WebSocket::run(&address).await;
 
         tokio::spawn(async {
@@ -232,14 +232,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 }
                             });
                         }
-                        if let Some(ref _address) = opt.offer_webhook.clone() {
+                        if let Some(ref _address) = opt.offer_websocket.clone() {
                             let now: DateTime<Utc> = Utc::now();
                             let ws_data = ws::channel::Data {
                                         offer: ws_str.clone(),
                                         ts: now.format("%Y-%m-%d %H:%M:%S").to_string(),
                             };
                                 if let Err(e) = sender.send(ws_data).await {
-                                    eprintln!("Error transmitting to offer webhook address: {}", e);
+                                    eprintln!("Error transmitting offer through websocket: {}", e);
                                 }
                         };
                     }
@@ -335,5 +335,5 @@ struct Opt {
         help = "Start a Websocket server to transmit offers",
         value_name = "HOST:PORT"
     )]
-    offer_webhook: Option<String>,
+    offer_websocket: Option<String>,
 }

--- a/src/ws/channel.rs
+++ b/src/ws/channel.rs
@@ -1,0 +1,37 @@
+use serde_json::json;
+use tokio::sync::mpsc;
+use std::error::Error;
+
+use super::server::WebSocket;
+
+pub struct Data {
+    pub offer: String,
+    pub ts: String,
+}
+
+pub async fn transmit(server: WebSocket, mut receiver: mpsc::Receiver<Data>) -> Result<(), Box<dyn Error>> {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(300));
+    let mut buffer = Vec::new();
+    loop {
+        tokio::select! {
+                Some(data) = receiver.recv() => {
+                    buffer.push(data);
+                },
+                _ = interval.tick() => {
+                    for data in buffer.drain(..) {
+                server
+                    .send(
+                        json!({
+                        "offer": data.offer,
+                        "ts": data.ts
+                        })
+                        .to_string(),
+                    )
+                    .await;
+        }}}
+        if false {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/src/ws/channel.rs
+++ b/src/ws/channel.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
-use tokio::sync::mpsc;
 use std::error::Error;
+use tokio::sync::mpsc;
 
 use super::server::WebSocket;
 
@@ -9,7 +9,10 @@ pub struct Data {
     pub ts: String,
 }
 
-pub async fn transmit(server: WebSocket, mut receiver: mpsc::Receiver<Data>) -> Result<(), Box<dyn Error>> {
+pub async fn transmit(
+    server: WebSocket,
+    mut receiver: mpsc::Receiver<Data>,
+) -> Result<(), Box<dyn Error>> {
     let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(300));
     let mut buffer = Vec::new();
     loop {

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -1,0 +1,2 @@
+pub mod channel;
+pub mod server;

--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -34,6 +34,11 @@ async fn handle_connection(peer: SocketAddr, stream: TcpStream, peers: PeerMap) 
     while let Some(msg) = rx.next().await {
         let msg = msg?;
         if msg.is_text() || msg.is_binary() {
+            eprintln!(
+                "Received text message from {}: {}",
+                peer,
+                msg.to_text().unwrap_or_default()
+            );
             // Echo the message back to the client
             for peer in peers.lock().await.iter_mut() {
                 peer.send(msg.clone()).await?;

--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -1,0 +1,88 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Mutex,
+};
+use tokio_tungstenite::{
+    accept_async,
+    tungstenite::{Error, Message, Result},
+    WebSocketStream,
+};
+
+type Tx = futures_util::stream::SplitSink<WebSocketStream<TcpStream>, Message>;
+type PeerMap = Arc<Mutex<Vec<Tx>>>;
+
+async fn accept_connection(peer: SocketAddr, stream: TcpStream, peers: PeerMap) {
+    if let Err(e) = handle_connection(peer, stream, peers).await {
+        match e {
+            Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
+            err => eprintln!("Error processing connection: {}", err),
+        }
+    }
+}
+
+async fn handle_connection(peer: SocketAddr, stream: TcpStream, peers: PeerMap) -> Result<()> {
+    let ws_stream = accept_async(stream).await.expect("Failed to accept");
+    let (tx, mut rx) = ws_stream.split();
+
+    peers.lock().await.push(tx);
+
+    eprintln!("New WebSocket connection: {}", peer);
+
+    while let Some(msg) = rx.next().await {
+        let msg = msg?;
+        if msg.is_text() || msg.is_binary() {
+            // Echo the message back to the client
+            for peer in peers.lock().await.iter_mut() {
+                peer.send(msg.clone()).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub struct WebSocket {
+    peers: PeerMap,
+}
+
+impl WebSocket {
+    pub async fn run(addr: &str) -> WebSocket {
+        let peers: PeerMap = Arc::new(Mutex::new(Vec::new()));
+
+        let addr = addr.to_string();
+        let peers_clone = peers.clone();
+
+        tokio::spawn(async move {
+            let listener = TcpListener::bind(&addr).await.expect("Can't listen");
+            eprintln!("Listening on: {}", addr);
+
+            while let Ok((stream, _)) = listener.accept().await {
+                let peer = stream
+                    .peer_addr()
+                    .expect("connected streams should have a peer address");
+                eprintln!("Peer address: {}", peer);
+
+                tokio::spawn(accept_connection(peer, stream, peers_clone.clone()));
+            }
+        });
+
+        WebSocket { peers }
+    }
+
+    pub async fn send(&self, msg: String) {
+        for peer in self.peers.lock().await.iter_mut() {
+            if let Err(e) = peer.send(Message::text(msg.clone())).await {
+                match e {
+                    Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
+                    Error::Io(ref err)
+                        if err.kind() == std::io::ErrorKind::ConnectionReset
+                            || err.kind() == std::io::ErrorKind::BrokenPipe => {}
+                    _ => eprintln!("Error sending message: {}", e),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
offers can be transmitted via a websocket server.
to enable use:
```bash
splash  --offer-websocket 0.0.0.0:4040
```

Then, using any websocket client or library you'll start receiving offers.
examples using CLI tools (open a new terminal first and leave `splash` running:

curl:
```bash
curl -i -N --http1.1 -H "Connection: Upgrade" \
-H "Upgrade: websocket" -H "Sec-WebSocket-Key: $(echo -n $RANDOM | base64)" \
-H "Sec-WebSocket-Version: 13" http://127.0.0.1:4040
```

[websocat](https://github.com/vi/websocat):
```bash
websocat ws://127.0.0.1:4040
```


Output:
```bash
{"offer":"offer1qqr83wcuu2rykcmqvpsxygqqemhmlaekcenaz02ma6hs5w600dhjlvfjn477nkwz369h88kll73h37fefnwk3qqnz8s0lle00pfzm3euw0l3dvgyfxy6pvmhfem0mcete0mha4unxa6c9cam2dys2njqy5kv03vky3ezmzud2vlnna2fl87elldt9f02e6zfu7y7970vld3u4ym9lldhtn7fdk7au5cgke58lk8wjp93x4zr7shdcjxezxa2s0t848vnezm0mnppnvkaxvx9u8e4n0a9xm783yg2kl0f27h4s6xley592llzweuvu433evd5k0nl3xd6mjq8327895ukq3vqfr3kmarfkmarekmarekmdres60fa35mdl6xh0sp30mstenmh6nnc6ldx30rddejdfpxuywcce6crenn6urvvmvva3ddmget2kz429shlfkwavla76me798uhgfrxnwwur755aa82mk7lwd8a4lfecp42r8cnkj4ypthqsmej509scyd4vhtleyt0ug9rdhmc0q6nd7kma0jk06uelssww4kn74099dqe79leyaw85fr2kpl28y60l2lcuu6nm4ztycprhqsq8s8xlc8lmhujht4l64fqclu07qjzahq07tvz6l6crzvt5rpqdzre6mcc0lm39u9hpe3cx0a74za53qt6h5unhsthjtnl2ru8l9tq5m30462qh035y00lzdtqsvk0umlc975x0xra98300j67u990a60mjd64lvwwdxhl9pv0xm6aprrkk7txrlgq3v0aluzew398vm07v7e4jv3ktaadrl6mxrnheac04u7ylzvapxa99get0ry0dkrwf98lpdhd30uwegxazhdyrwvlxc3fn0atwmvf6hnyyt0tdjnde8th0cql865rlut73l5ew95grulmyh0nwef76c5u6h0a7m5ltw0nucd8xmh7wad828wrx7cl7t095cw3ur0lzuufmjf743f4x8rny3gemstjck2wvn0lqwnk2h3j8c3vugmzu7l0nhz55pkcfxnslut3q6kys9kxkjtgyr92cqladmlywh959e8pvkhvzs3z3alclcvjnxfz67054lsd2d86e8nevuuuctrsn2klkywyx4y6km0mk78d24czs20zdnkhxe46jafjlq6k26u5mkm05muztjd5ulhyfrsd65ys90zt4lue4kjgrps7v0rt7zumy2w6vlnm98jrdhah94gmzhv5a47swlla2mye89e7jewtlv4ylha0tfszw44cnlg8tsqsmh6pvutanh40","ts":"2024-02-01 01:02:25"}
```